### PR TITLE
[feat] add mmengine-cli

### DIFF
--- a/mmengine/cli/__init__.py
+++ b/mmengine/cli/__init__.py
@@ -1,0 +1,55 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from abc import ABC
+from argparse import Namespace, _SubParsersAction
+
+from .tasks import Task
+
+_JOBS: dict[str, Task] = {}
+
+
+class BaseCLICommand(ABC):
+    """Abstract CLI command class."""
+
+    command: str = 'undefined'
+    jobs: list[type[Task]] = []
+
+    @classmethod
+    def register_subcommand(cls, parser: _SubParsersAction):
+        r"""An abstract static method to add a command to subparsers.
+
+        Example:
+
+            class DatasetCommand(BaseCLICommand):
+                command = "dataset"
+                jobs = [TaskCls1, TaskCls2]
+        """
+        subparser = parser.add_parser(
+            cls.command,
+            usage=f"{cls.command} <command> [<args>]",
+            description=f"{cls.command.upper()} Command Line Interface (CLI)",
+        )
+        gpu_parser = subparser.add_subparsers(
+            help=f"{cls.command} helpers", dest='command'
+        )
+        subparser.set_defaults(func=cls)
+        for job in cls.jobs:
+            cls.add_job(job(gpu_parser))
+
+    @staticmethod
+    def add_job(job: Task):
+        """Add a specific job to the command."""
+        _JOBS[job.command] = job
+
+    @staticmethod
+    def run(args: Namespace):
+        """Run the command."""
+
+        if args.command not in _JOBS:
+            print(
+                'Error: missing a valid command. '
+                f"Choose from: {sorted(_JOBS.keys())}"
+            )
+            exit(1)
+
+        ret = _JOBS[args.command].run(args)
+        raise SystemExit(ret)

--- a/mmengine/cli/__main__.py
+++ b/mmengine/cli/__main__.py
@@ -1,0 +1,31 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from argparse import ArgumentParser
+
+from ..version import __version__
+from .command import DatasetCommand
+
+
+def main():
+    """Entry of mmengine command line interface (CLI)"""
+    parser = ArgumentParser(
+        'mmengine-cli',
+        usage='mmengine-cli <command> [<args>]',
+        description='MMEngine Command Line Interface (CLI)',
+    )
+    parser.add_argument(
+        '--version', '-V', action='version', version=f"%(prog)s {__version__}"
+    )
+    subparser = parser.add_subparsers(help='mmengine-cli command helpers')
+
+    DatasetCommand.register_subcommand(subparser)
+
+    args = parser.parse_args()
+    if not hasattr(args, 'func'):
+        parser.print_help()
+        exit(1)
+
+    args.func.run(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/mmengine/cli/command.py
+++ b/mmengine/cli/command.py
@@ -1,0 +1,10 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from . import BaseCLICommand
+from .tasks.browse_dataset import BrowseDatasetTask
+
+
+class DatasetCommand(BaseCLICommand):
+    """Dataset Interface (CLI)"""
+
+    command = 'dataset'
+    jobs = [BrowseDatasetTask]

--- a/mmengine/cli/tasks/__init__.py
+++ b/mmengine/cli/tasks/__init__.py
@@ -1,0 +1,24 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from abc import abstractmethod
+from argparse import ArgumentParser, Namespace, _SubParsersAction
+
+
+class Task:
+    """Abstract base class for all command jobs."""
+
+    command: str = 'unknown'
+    description: str | None = None
+
+    @classmethod
+    @abstractmethod
+    def add_arguments(cls, parser: ArgumentParser):
+        """Add arguments to this command."""
+
+    @abstractmethod
+    def run(self, args: Namespace) -> int:
+        """Run this command."""
+        return 0
+
+    def __init__(self, subparsers: _SubParsersAction):
+        parser = subparsers.add_parser(self.command, description=self.description)
+        self.add_arguments(parser)

--- a/mmengine/cli/tasks/browse_dataset.py
+++ b/mmengine/cli/tasks/browse_dataset.py
@@ -79,7 +79,7 @@ class BrowseDatasetTask(Task):
                     encoding='utf-8',
                 ) as f:
                     f.write(
-                        f"The source filepath of img_{img_idx}.jpg"
+                        f"The source filepath of img_{img_idx}.jpg "
                         f"is `{img_path}`.\n"
                     )
 

--- a/mmengine/cli/tasks/browse_dataset.py
+++ b/mmengine/cli/tasks/browse_dataset.py
@@ -1,0 +1,159 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import importlib
+import os.path as osp
+from argparse import ArgumentParser, Namespace
+
+from mmengine import ProgressBar, init_default_scope
+from mmengine.config import Config, DictAction
+from mmengine.registry import DATASETS, VISUALIZERS
+from . import Task
+
+
+class BrowseDatasetTask(Task):
+    """Browse the dataset defined in a config file."""
+
+    command = 'browse'
+
+    @classmethod
+    def add_arguments(cls, parser: ArgumentParser):
+        parser.add_argument('config', help='train config file path')
+        parser.add_argument(
+            '--save-dir',
+            default=None,
+            type=str,
+            help='If there is no display interface, you can save it',
+        )
+        parser.add_argument(
+            '--show', action='store_true', help='display the visualization results'
+        )
+        parser.add_argument(
+            '--show-interval', type=float, default=2, help='the interval of show (s)'
+        )
+        parser.add_argument(
+            '--max-count', type=int, default=100, help='max count of samples to browse'
+        )
+        parser.add_argument(
+            '--mode',
+            default='train',
+            choices=['train', 'val', 'test'],
+            help='choose a type of dataset to browse. Defaults to train',
+        )
+        parser.add_argument(
+            '--cfg-options',
+            nargs='+',
+            action=DictAction,
+            help='override some settings in the used config, the key-value pair '
+            'in xxx=yyy format will be merged into config file. If the value to '
+            'be overwritten is a list, it should be like key="[a,b]" or key=a,b '
+            'It also allows nested list/tuple values, e.g. key="[(a,b),(c,d)]" '
+            'Note that the quotation marks are necessary and that no white space '
+            'is allowed.',
+        )
+
+    def _visual_mmdet(self, args, visualizer, idx, item):
+        data_sample = item['data_samples']
+        inputs = item['inputs']
+        for img_idx, img_data_sample in enumerate(data_sample):
+            img_path = img_data_sample.img_path
+            img = inputs[img_idx].permute(1, 2, 0).numpy()
+            out_file = (
+                osp.join(args.save_dir, str(idx).zfill(6), f"img_{img_idx}.jpg")
+                if args.save_dir is not None
+                else None
+            )
+            img = img[..., [2, 1, 0]]  # bgr to rgb
+            visualizer.add_datasample(
+                osp.basename(img_path),
+                img,
+                data_sample=img_data_sample,
+                draw_pred=False,
+                show=args.show,
+                wait_time=args.show_interval,
+                out_file=out_file,
+            )
+            # Record file path mapping.
+            if args.save_dir is not None:
+                with open(
+                    osp.join(args.save_dir, str(idx).zfill(6), 'info.txt'),
+                    'a',
+                    encoding='utf-8',
+                ) as f:
+                    f.write(
+                        f"The source filepath of img_{img_idx}.jpg"
+                        f"is `{img_path}`.\n"
+                    )
+
+    def _visual_mmseg(self, args, visualizer, idx, item):
+        inputs = item['inputs']
+        if inputs.ndim == 3:
+            imgs = item['inputs'].permute(1, 2, 0).numpy()
+            imgs = imgs[None]  # expand to [1, H, W, C]
+        elif inputs.ndim == 4:
+            imgs = item['inputs'].permute(0, 2, 3, 1).numpy()
+        else:
+            raise ValueError(f"inputs ndim should be 3 or 4, but got {inputs.ndim}")
+        imgs = imgs[..., [2, 1, 0]]  # bgr to rgb
+        data_sample = item['data_samples'].numpy()
+        img_path = osp.basename(item['data_samples'].img_path)
+
+        out_file = (
+            osp.join(args.save_dir, osp.basename(img_path))
+            if args.save_dir is not None
+            else None
+        )
+
+        has_gt = 'gt_sem_seg' in data_sample
+        if has_gt:
+            gt_sem_seg = data_sample.gt_sem_seg.data.copy()
+        for idx, img in enumerate(imgs):
+            if has_gt:
+                data_sample.gt_sem_seg.data = gt_sem_seg[:, idx]  # type: ignore
+            visualizer.add_datasample(
+                name=osp.basename(img_path) + f"%{idx}",
+                image=img.copy(),
+                data_sample=data_sample,
+                draw_gt=True,
+                draw_pred=False,
+                wait_time=args.show_interval,
+                out_file=out_file,
+                show=args.show,
+            )
+
+    def run(self, args: Namespace) -> int:
+        cfg = Config.fromfile(args.config)
+        if args.cfg_options is not None:
+            cfg.merge_from_dict(args.cfg_options)
+
+        scope = cfg.get('default_scope', 'mmdet')
+        init_default_scope(scope)
+        importlib.import_module('.datasets', scope)
+
+        if scope in DATASETS.children:
+            dataset = DATASETS.children[scope].build(
+                cfg[f"{args.mode}_dataloader"].dataset
+            )
+        else:
+            dataset = DATASETS.build(cfg[f"{args.mode}_dataloader"].dataset)
+
+        if scope in VISUALIZERS.children:
+            visualizer = VISUALIZERS.children[scope].build(cfg.visualizer)
+        else:
+            visualizer = VISUALIZERS.build(cfg.visualizer)
+        visualizer.dataset_meta = dataset.metainfo
+
+        progress_bar = ProgressBar(len(dataset))
+        for idx, item in enumerate(dataset):  # inputs data_samples
+            if scope == 'mmdet':
+                self._visual_mmdet(args, visualizer, idx, item)
+            elif scope == 'mmseg':
+                self._visual_mmseg(args, visualizer, idx, item)
+            else:
+                raise NotImplementedError(
+                    f"Browsing for {scope} is not implemented. "
+                    f"You could edit this file {__file__} by adding a function "
+                    'like `_visual_mmseg`'
+                )
+            progress_bar.update()
+            if idx >= args.max_count - 1:
+                break
+        return 0

--- a/mmengine/structures/pixel_data.py
+++ b/mmengine/structures/pixel_data.py
@@ -114,7 +114,7 @@ class PixelData(BaseDataElement):
             item3 = tuple(tmp_item)
             item4 = (slice(None, None, None),) + item3
             for k, v in self.items():
-                assert v.ndim in (3, 4)
+                assert v.ndim in (3, 4), f"Expected tensor with 3 or 4 dimensions, got {v.ndim}"
                 setattr(new_data, k, v[item3] if v.ndim == 3 else v[item4])
         else:
             raise TypeError(

--- a/mmengine/structures/pixel_data.py
+++ b/mmengine/structures/pixel_data.py
@@ -76,8 +76,8 @@ class PixelData(BaseDataElement):
                     ':obj:`PixelData` '
                     f'{self.shape}')
             assert value.ndim in [
-                2, 3
-            ], f'The dim of value must be 2 or 3, but got {value.ndim}'
+                2, 3, 4
+            ], f'The dim of value must be 2, 3, or 4, but got {value.ndim}'
             if value.ndim == 2:
                 value = value[None]
                 warnings.warn('The shape of value will convert from '
@@ -111,9 +111,11 @@ class PixelData(BaseDataElement):
                         'The type of element in input must be int or slice, '
                         f'but got {type(single_item)}')
             tmp_item.insert(0, slice(None, None, None))
-            item = tuple(tmp_item)
+            item3 = tuple(tmp_item)
+            item4 = (slice(None, None, None),) + item3
             for k, v in self.items():
-                setattr(new_data, k, v[item])
+                assert v.ndim in (3, 4)
+                setattr(new_data, k, v[item3] if v.ndim == 3 else v[item4])
         else:
             raise TypeError(
                 f'Unsupported type {type(item)} for slicing PixelData')

--- a/mmengine/version.py
+++ b/mmengine/version.py
@@ -1,6 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 
-__version__ = '0.10.9'
+__version__ = '0.10.10'
 
 
 def parse_version_info(version_str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,5 +51,8 @@ tests = [
     "transformers",
 ]
 
+[project.scripts]
+mmengine-cli = "mmengine.cli.__main__:main"
+
 [tool.uv.sources]
 mmengine-config = { git = "https://github.com/llteco/mmengine-config.git" }


### PR DESCRIPTION
Bump version to 0.10.10 and introduce a new feature: **mmengine-cli**
A command line tool to integrate scripts and tools.

Integrate tasks:
- Browse dataset: `mmengine-cli dataset browse <config>`

Develop:
Expand "command" or "task", see example in `command.py` and `browse_dataset.py`
