### PR TITLE
[dev] add weights_only args to checkpoint loader

### DIFF
--- a/mmengine/utils/dl_utils/hub.py
+++ b/mmengine/utils/dl_utils/hub.py
@@ -55,7 +55,8 @@ if TORCH_VERSION != 'parrots' and digit_version(TORCH_VERSION) < digit_version(
                  map_location=None,
                  progress=True,
                  check_hash=False,
-                 file_name=None):
+                 file_name=None,
+                 weights_only=True):
         r"""Loads the Torch serialized object at the given URL.
 
         If downloaded file is a zip file, it will be automatically decompressed
@@ -78,6 +79,7 @@ if TORCH_VERSION != 'parrots' and digit_version(TORCH_VERSION) < digit_version(
                 Defaults to False
             file_name (str, optional): name for the downloaded file. Filename
                 from ``url`` will be used if not set. Defaults to None.
+            weights_only (bool, optional): see torch.load
         Example:
             >>> url = ('https://s3.amazonaws.com/pytorch/models/resnet18-5c106'
             ...        'cde.pth')
@@ -114,7 +116,10 @@ if TORCH_VERSION != 'parrots' and digit_version(TORCH_VERSION) < digit_version(
             return _legacy_zip_load(cached_file, model_dir, map_location)
 
         try:
-            return torch.load(cached_file, map_location=map_location)
+            return torch.load(
+                cached_file,
+                map_location=map_location,
+                weights_only=weights_only)
         except RuntimeError as error:
             if digit_version(TORCH_VERSION) < digit_version('1.5.0'):
                 warnings.warn(

--- a/tests/test_runner/test_checkpoint.py
+++ b/tests/test_runner/test_checkpoint.py
@@ -316,7 +316,7 @@ def test_checkpoint_loader():
         assert loader.__name__ == fn_name
 
     @CheckpointLoader.register_scheme(prefixes='ftp://')
-    def load_from_ftp(filename, map_location):
+    def load_from_ftp(filename, map_location, **kwargs):
         return dict(filename=filename)
 
     # test register_loader
@@ -324,7 +324,7 @@ def test_checkpoint_loader():
     loader = CheckpointLoader._get_checkpoint_loader(filename)
     assert loader.__name__ == 'load_from_ftp'
 
-    def load_from_ftp1(filename, map_location):
+    def load_from_ftp1(filename, map_location, **kwargs):
         return dict(filename=filename)
 
     # test duplicate registered error


### PR DESCRIPTION
Set `weights_only=False` by default in order to load previous saved checkpoints without exception.